### PR TITLE
feat: MainActivity에 현재 층 입력 다이얼로그 UI 추가

### DIFF
--- a/frontend/app/src/main/java/com/capstone/whereigo/MainActivity.java
+++ b/frontend/app/src/main/java/com/capstone/whereigo/MainActivity.java
@@ -7,9 +7,14 @@ import android.speech.SpeechRecognizer;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
+import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.Toast;
 import android.content.Intent;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.core.view.WindowCompat;
+
 
 import androidx.activity.OnBackPressedCallback;
 import androidx.activity.EdgeToEdge;
@@ -45,7 +50,7 @@ public class MainActivity extends AppCompatActivity {
         backButton.setOnClickListener(v -> {
             Intent intent = new Intent(MainActivity.this, SearchActivity.class);
             startActivity(intent);
-            finish();  // 현재 MainActivity 종료
+            finish();
         });
 
         ImageButton settingsButton = findViewById(R.id.settings_button);
@@ -56,9 +61,32 @@ public class MainActivity extends AppCompatActivity {
                 .commit());
 
         if (savedInstanceState == null) {
-            getSupportFragmentManager().beginTransaction()
-                    .replace(R.id.fragment_container, new HelloArFragment())
-                    .commit();
+            showFloorInputDialog();
         }
+    }
+
+    private void showFloorInputDialog() {
+        View dialogView = getLayoutInflater().inflate(R.layout.dialog_floor_input, null);
+        EditText editText = dialogView.findViewById(R.id.edit_floor_input);
+
+        new AlertDialog.Builder(this)
+                .setTitle("현재 층 입력")
+                .setView(dialogView)
+                .setCancelable(false)
+                .setPositiveButton("확인", (dialog, which) -> {
+                    String input = editText.getText().toString().trim();
+                    if (!input.isEmpty()) {
+                        Toast.makeText(this, input + "층 선택됨", Toast.LENGTH_SHORT).show();
+
+                        // HelloArFragment 로드
+                        getSupportFragmentManager().beginTransaction()
+                                .replace(R.id.fragment_container, new HelloArFragment())
+                                .commit();
+                    } else {
+                        Toast.makeText(this, "층을 입력해주세요", Toast.LENGTH_SHORT).show();
+                        showFloorInputDialog(); // 재실행
+                    }
+                })
+                .show();
     }
 }

--- a/frontend/app/src/main/java/com/capstone/whereigo/SearchActivity.java
+++ b/frontend/app/src/main/java/com/capstone/whereigo/SearchActivity.java
@@ -60,7 +60,6 @@ public class SearchActivity extends AppCompatActivity {
             return true;
         });
 
-        // 데이터 리스트
         allResults = new ArrayList<>();
         allResults.add("미래관 445호");
         allResults.add("미래관 447호");

--- a/frontend/app/src/main/res/layout/dialog_floor_input.xml
+++ b/frontend/app/src/main/res/layout/dialog_floor_input.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minWidth="300dp"
+    android:minHeight="120dp"
+    android:orientation="vertical"
+    android:padding="32dp"
+    android:gravity="center_vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <EditText
+            android:id="@+id/edit_floor_input"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="2"
+            android:hint="현재 층을 입력하세요"
+            android:inputType="number"
+            android:textSize="16sp"
+            android:padding="20dp" />
+
+        <ImageButton
+            android:id="@+id/btn_stt"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_marginStart="8dp"
+            android:src="@drawable/baseline_mic_48"
+            android:contentDescription="음성 입력"
+            android:background="?android:selectableItemBackgroundBorderless"
+            android:scaleType="centerInside" />
+    </LinearLayout>
+</LinearLayout>

--- a/frontend/app/src/main/res/values/strings.xml
+++ b/frontend/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
 
     <string name="save_date">저장 일자 : %s</string>
     <string name="file_size">저장 용량 : %s</string>
-    <string name="searchbar_hint">검색...</string>
+    <string name="searchbar_hint">목적지를 입력해주세요..</string>
     <string name="fab_content_desc">메뉴 버튼</string>
 
     <!-- Preference Titles -->


### PR DESCRIPTION
### ✨주요 변경 사항
- 앱 실행 시 현재 층을 입력할 수 있는 다이얼로그 UI 추가
  - EditText를 통해 직접 층 번호 입력 가능
  - 마이크 버튼 추가
- 층 입력 완료 후 HelloArFragment를 정상 로드하도록 처리

### 🧩UI 구성
- `dialog_floor_input.xml`: EditText + ImageButton(마이크 버튼) 수평 정렬
- 다이얼로그 크기 확대 및 시인성 개선 (padding, minWidth 등 조정)

### 📎참고 사항
- 이후 층 정보를 전달하고자 한다면 후속 작업 필요
- STT 기능 추가 필요