### PR TITLE
Fragment 간 변화시 비어있다면 이전 Activity로 전환하도록 코드 수정

### DIFF
--- a/frontend/app/src/main/java/com/capstone/whereigo/SearchActivity.java
+++ b/frontend/app/src/main/java/com/capstone/whereigo/SearchActivity.java
@@ -134,7 +134,6 @@ public class SearchActivity extends AppCompatActivity {
         binding.settingsButton.setOnClickListener(v -> {
             Intent intent = new Intent(SearchActivity.this, SettingActivity.class);
             startActivity(intent);
-            finish();
         });
 
         getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {

--- a/frontend/app/src/main/java/com/capstone/whereigo/SettingActivity.java
+++ b/frontend/app/src/main/java/com/capstone/whereigo/SettingActivity.java
@@ -23,9 +23,13 @@ public class SettingActivity extends AppCompatActivity {
         EdgeToEdge.enable(this);
         binding = ActivitySettingBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
-
+        
         binding.toolbar.setNavigationOnClickListener(v -> {
-            getSupportFragmentManager().popBackStack();
+            if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
+                getSupportFragmentManager().popBackStack();
+            } else {
+                finish();
+            }
         });
 
         ViewCompat.setOnApplyWindowInsetsListener(binding.settingMain, (v, insets) -> {


### PR DESCRIPTION
## 변경 내용
- 기존에는 Fragment 간 뒤로가기는 지원되지만, Fragment stack이 비어도 Activity는 종료되지 않아 사용자가 명시적으로 앱을 종료해야 했음
- FragmentManager의 back stack이 비었을 때 `finish()`를 호출하여 Activity도 함께 종료되도록 처리함.

## 변경 이유
- UX 개선: 마지막 Fragment에서 뒤로가기 버튼을 눌렀을 때 앱이 종료되는 것이 자연스러운 흐름.
- Fragment 간 이동이 아닌 Activity 종료를 명확히 구분해 사용자 경험을 향상

## 관련 이슈
- Fixes #42  
  SettingActivity에서 뒤로가기 시 Fragment 전환만 수행되고 Activity는 종료되지 않는 버그 해결

## 테스트
- Fragment A → B → C 순으로 이동 후 뒤로가기를 눌렀을 때, C → B → A → 앱 종료 흐름이 정상 동작함을 확인함.

## 기타
- 추후 필요 시 `onBackPressedDispatcher` 또는 Navigation Component 사용 고려 가능.
