### PR TITLE
Fix/#48 목적지 검색창의 뒤로가기 UI가 검색창과 겹치는 문제

### DIFF
--- a/frontend/app/src/main/java/com/capstone/whereigo/HelloArFragment.java
+++ b/frontend/app/src/main/java/com/capstone/whereigo/HelloArFragment.java
@@ -101,11 +101,13 @@ public class HelloArFragment extends Fragment {
     int searchMenu = R.menu.search_menu;
     searchBar.inflateMenu(searchMenu);
 
-    ImageButton settingsButton = binding.settingsButton;
-    settingsButton.setOnClickListener(v -> {
-      Intent intent = new Intent(requireContext(), SettingActivity.class);
-      startActivity(intent);
-      requireActivity().finish();
+    ImageButton backButton = binding.backButton;
+    backButton.setOnClickListener(v -> {
+      if (getParentFragmentManager().getBackStackEntryCount() > 0) {
+        getParentFragmentManager().popBackStack();
+      } else {
+        requireActivity().onBackPressed();
+      }
     });
 
     searchBar.getMenu().findItem(R.id.action_voice_search).setOnMenuItemClickListener(item -> {
@@ -240,9 +242,9 @@ public class HelloArFragment extends Fragment {
 
     if (requestCode == RECORD_AUDIO_REQUEST_CODE) {
       if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-        Toast.makeText(activity, "음성 권한이 허용되었습니다. 다시 시도해주세요.", Toast.LENGTH_SHORT).show();
+        Toast.makeText(activity, "음성 권한이 허용되었습니다.", Toast.LENGTH_SHORT).show();
       } else {
-        Toast.makeText(activity, "음성 권한이 거부되었습니다.", Toast.LENGTH_SHORT).show();
+        Toast.makeText(activity, "음성 권한이 거부되었습니다. 다시 시도해주세요.", Toast.LENGTH_SHORT).show();
       }
     }
   }

--- a/frontend/app/src/main/res/drawable/ic_back_black.xml
+++ b/frontend/app/src/main/res/drawable/ic_back_black.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:autoMirrored="true"
+    android:height="24dp" android:tint="@color/black" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+    <path android:fillColor="@android:color/black"
+        android:pathData="M20,11H7.83l5.59,-5.59L12,4l-8,8 8,8 1.41,-1.41L7.83,13H20v-2z"/>
+    
+</vector>

--- a/frontend/app/src/main/res/layout/fragment_hello_ar.xml
+++ b/frontend/app/src/main/res/layout/fragment_hello_ar.xml
@@ -18,6 +18,19 @@
         android:adjustViewBounds="true"
         android:padding="4dp" />
 
+    <ImageButton
+        android:id="@+id/backButton"
+        android:layout_width="50dp"
+        android:layout_height="50dp"
+        android:layout_gravity="top|start"
+        android:layout_marginTop="30dp"
+        android:layout_marginStart="7dp"
+        android:src="@drawable/ic_back_black"
+        android:background="?android:attr/windowBackground"
+        android:scaleType="fitCenter"
+        android:adjustViewBounds="true"
+        android:padding="4dp" />
+
     <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -28,7 +41,7 @@
             android:layout_width="310dp"
             android:layout_height="50dp"
             android:layout_marginTop="30dp"
-            android:layout_marginStart="16dp"
+            android:layout_marginStart="60dp"
             android:layout_marginEnd="60dp"
             android:hint="@string/searchbar_hint"
             android:layout_gravity="top" />


### PR DESCRIPTION
## 관련 이슈
- closes #48

## 변경 사항
- 목적지 검색 화면의 `뒤로가기` 버튼이 `검색창(SearchBar)`과 겹치는 UI 문제를 해결
- `backButton`의 `layout_marginTop` 또는 `layout_z-order` 조정.
- 필요 시 `CoordinatorLayout` 또는 `ConstraintLayout` 내 레이아웃 구조 개선.

## 테스트
- 앱 실행 후 목적지 검색 화면에서 뒤로가기 버튼이 검색창과 겹치지 않는지 확인.
- 여러 해상도 및 기기에서 레이아웃이 정상적으로 보이는지 확인.

## 기타 참고 사항
- UI 겹침 문제는 `SearchBar`가 `AppBar`로서 배치될 때 발생할 수 있어 layout 구조도 일부 수정.
